### PR TITLE
Fix warning criterion html reports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = { version = "0.9.5", optional = true }
 # aes-ctr = {version = "0.6.0", optional = true}
 
 [dev-dependencies]
-criterion = "0.3.4"
+criterion = { version = "0.3.6", features = ["html_reports"] }
 rand = "0.8.3"
 
 [build-dependencies]


### PR DESCRIPTION
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

