### PR TITLE
Fix: windows avx2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,34 @@
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master, development ] 
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [
+          i686-pc-windows-gnu, 
+          i686-pc-windows-msvc, 
+          x86_64-pc-windows-gnu, 
+          x86_64-pc-windows-msvc, 
+          aarch64-pc-windows-msvc
+        ]
+
+        rust: [1.47.0, stable]  # MSRV 1.47
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      
+      - name: Run Tests
+        shell: bash
+        working-directory: ./tests
+        run: ./run_all_tests.sh

--- a/src/avx2/consts.rs
+++ b/src/avx2/consts.rs
@@ -2,7 +2,6 @@ use core::arch::x86_64::*;
 use crate::params::KYBER_Q;
 
 pub(crate) const Q: i16 = KYBER_Q as i16;
-// pub(crate) const MONT: i16 = -1044;       // 2^16 mod q
 pub(crate) const QINV: i16 = -3327;       // q^-1 mod 2^16
 pub(crate) const V: i16 = 20159;          // floor(2^26/q + 0.5)
 pub(crate) const FHI: i16 = 1441;         // mont^2/128

--- a/src/avx2/indcpa.rs
+++ b/src/avx2/indcpa.rs
@@ -608,7 +608,7 @@ pub fn indcpa_enc(c: &mut[u8], m: &[u8], pk: &[u8], coins: &[u8])
       poly_getnoise_eta2(&mut epp, coins, 4); 
     } 
 
-    #[cfg(not(any(feature="kyber1024", feature="kyber512", feature="90s")))] // kyber768)
+    #[cfg(not(any(feature="kyber1024", feature="kyber512", feature="90s")))]
     {
       let (sp0, sp1) = sp.vec.split_at_mut(1);
       let (sp1, sp2) = sp1.split_at_mut(1);

--- a/src/avx2/poly.rs
+++ b/src/avx2/poly.rs
@@ -7,6 +7,7 @@ use crate::{
   fips202x4::*,
   params::*,
   symmetric::*,
+  reference::ntt::*
 };
 
 pub(crate) const NOISE_NBLOCKS: usize = 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ mod reference;
 #[cfg(any(not(target_arch = "x86_64"), not(feature = "avx2")))] 
 use reference::*;
 
+#[cfg(target_family = "windows")]
+mod reference;
+
 #[cfg(feature = "wasm")]
 mod wasm;
 


### PR DESCRIPTION
The Kyber C reference uses GAS[1] rather than a more common syntax like NASM/MASM. The optimised version will segfault if built for/on most windows systems.

Until there is an alternative, we will use the rust reference NTT functions rather than the optimised assembly files. This still allows for avx2 improvements on x86 windows platforms without forcing those users into the fully portable code

[1] https://github.com/pq-crystals/kyber/issues/41