### PR TITLE
Replace KAT feature with rustflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,6 @@ zero = ["zeroize"]
 # For benchmarking
 benchmarking = ["criterion"]
 
-# Known Answer Tests
-# Allows private internal api access to seed the RNG output.
-# Do not use this feature for any purpose other than testing.
-KAT = []
-
 # Prevents leak sanitiser failing in tests
 [profile.test]
 opt-level = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,5 +154,5 @@ pub use rand_core::{RngCore, CryptoRng};
 // Feature hack to expose private functions for the Known Answer Tests
 // and fuzzing. Will fail to compile if used outside `cargo test` or 
 // the fuzz binaries.
-#[cfg(any(feature="KAT", fuzzing))]
+#[cfg(any(kyber_kat, fuzzing))]
 pub use kem::*;

--- a/tests/KAT/build_kats.sh
+++ b/tests/KAT/build_kats.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -e
 
-current_dir="${PWD##*/}"
-if [ $current_dir != "KAT" ];
-then
-  echo "Script needs to be run from inside the KAT folder";
-  echo "Current working directory: "$current_dir
-  exit;
-fi;
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
 
 git clone https://github.com/pq-crystals/kyber.git;
 cd kyber/ref;

--- a/tests/kat.rs
+++ b/tests/kat.rs
@@ -1,4 +1,4 @@
-#![cfg(feature="KAT")]
+#![cfg(kyber_kat)]
 
 mod load;
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -10,14 +10,15 @@ set -e
 
 TARGET=$(rustc -vV | sed -n 's|host: ||p')
 
+RUSTFLAGS=${RUSTFLAGS:-""}
+
 # KAT and AVX2 bash variables
 if [ -z "$KAT" ]
   then
     echo Not running Known Answer Tests 
-    KAT=""
   else
   echo Running Known Answer Tests
-    KAT="KAT"
+    RUSTFLAGS+=" --cfg kyber_kat"
 fi
 
 if [ -z "$AVX2" ]
@@ -52,9 +53,9 @@ for level in "${LEVELS[@]}"; do
   for nine in "${NINES[@]}"; do
     for opt in "${OPT[@]}"; do
       name="$level $nine $opt"
-      feat=${level:+"$level"}${opt:+",$opt"}${nine:+",$nine"}${KAT:+",$KAT"}
+      feat=${level:+"$level"}${opt:+",$opt"}${nine:+",$nine"}
       announce "$name"
-      cargo test --features  $feat
+      RUSTFLAGS=$RUSTFLAGS cargo test --features $feat
       break;
     done
   done


### PR DESCRIPTION
Exposing the test-only KAT stuff via a user facing cargo feature is IMHO not optimal. Users are never supposed to use it. So better to not expose it. Here I instead went the route that `loom` uses and recommends: https://docs.rs/loom/latest/loom/#running-loom-tests. To inject a `--cfg <some name>` to the build when you want the crate to compile for a certain type of testing.