### PR TITLE
Fix the "zeroise" spelling error, and use the feature directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,6 @@ avx2 = []
 # For compiling to wasm targets 
 wasm = ["wasm-bindgen", "getrandom", "rand"]
 
-zero = ["zeroize"]
-
 # For benchmarking
 benchmarking = ["criterion"]
 

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ pqc_kyber = {version = "0.2.0", features = ["kyber512", "90s", "avx2"]}
 | 90s       | Uses SHA2 and AES in counter mode as a replacement for SHAKE. This can provide hardware speedups in some cases. |
 | avx2      | On x86_64 platforms enable the optimized version. This flag is will cause a compile error on other architectures. |
 | wasm      | For compiling to WASM targets.                                                                                                                                     |
-| zero      | This will zero out the key exchange structs on drop using the [zeroize](https://docs.rs/zeroize/latest/zeroize/) crate |
+| zeroize      | This will zero out the key exchange structs on drop using the [zeroize](https://docs.rs/zeroize/latest/zeroize/) crate |
 | benchmarking |  Enables the criterion benchmarking suite |
 ---
 

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -1,5 +1,5 @@
 use rand_core::{RngCore, CryptoRng};
-#[cfg(feature = "zeroise")]
+#[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::{
   kem::*,
@@ -58,7 +58,7 @@ type Eska = [u8; KYBER_SECRETKEYBYTES];
 /// assert_eq!(alice.shared_secret, bob.shared_secret);
 /// # Ok(()) }
 
-#[cfg_attr(feature = "zeroise", derive(Zeroize, ZeroizeOnDrop))]
+#[cfg_attr(feature = "zeroize", derive(Zeroize, ZeroizeOnDrop))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Uake {
   /// The resulting shared secret from a key exchange
@@ -186,7 +186,7 @@ impl Uake {
 /// # Ok(()) }
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "zeroise", derive(Zeroize, ZeroizeOnDrop))]
+#[cfg_attr(feature = "zeroize", derive(Zeroize, ZeroizeOnDrop))]
 pub struct Ake {
   /// The resulting shared secret from a key exchange
   pub shared_secret: SharedSecret,


### PR DESCRIPTION
It was not possible to activate the zeroizing feature in this crate. Because neither "zero" nor "zeroize" actually activated the implementation due to a spelling error.

Skip creating an extra feature "zero" and instead just use the one called "zeroize" by having the dependency optional. This is more idiomatic and avoids creating a set of basically duplicate features.

It should however be noted that the zeroize functionality is currently somewhat limited. Yes the `Uake` and `Ake` types can be cleared out. But the `SharedSecret` produced by the library is just a raw array without `Zeroize`. I'd suggest that more long term we look into doing something similar to what I added to `classic-mceliece` in https://github.com/Colfenor/classic-mceliece-rust/pull/20. This means that types containing secrets can no longer just be type definitions translating to arrays. Rather they should probably be structs owning the secret data, and clear on drop. But all of this can be done later of course.