### PR TITLE
Bump deps

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # MSRV 1.47
-        rust: [stable, 1.47.0] 
+        # MSRV 1.47 temporarily removed
+        # See https://github.com/Argyle-Software/kyber/issues/34
+        rust: [stable] 
     
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["kyber", "kem", "key-exchange", "kex", "post-quantum"]
 readme = "readme.md"
 
 [dependencies]
-rand_core = {version = "0.6.2",  default-features = false }
+rand_core = {version = "0.6.4",  default-features = false }
 wasm-bindgen = { version = "0.2.83", optional = true }
-sha2 = { version = "0.10.2", optional = true }
-getrandom = {version = "0.2.7", features = ["js"], optional = true}
-zeroize = { version = "1.5.3", features = ["derive"], optional = true}
-criterion = { version = "0.3.6", features = ["html_reports"], optional = true}
+sha2 = { version = "0.10.6", optional = true }
+getrandom = {version = "0.2.8", features = ["js"], optional = true}
+zeroize = { version = "1.5.7", features = ["derive"], optional = true}
+criterion = { version = "0.4.0", features = ["html_reports"], optional = true}
 
 # TODO: Add rustcrypto AES-CTR feature for 90's mode
 # aes-ctr = {version = "0.6.0", optional = true}
@@ -32,7 +32,7 @@ optional = true
 rand = "0.8.3"
 
 [build-dependencies]
-cc = "1.0.73"
+cc = "1.0.76"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/readme.md
+++ b/readme.md
@@ -155,16 +155,20 @@ pqc_kyber = {version = "0.2.0", features = ["kyber512", "90s", "avx2"]}
 
 ## Testing
 
-The [run_all_tests](tests/run_all_tests.sh) script will traverse all possible codepaths by running a matrix of the security levels and variants.
+The [run_all_tests](tests/run_all_tests.sh) script will traverse all possible codepaths by running a matrix of the security levels, variants and crate features.
 
-Known Answer Tests require deterministic rng seeds, enable the `KAT` feature to run them. Using this feature outside of `cargo test` will result in a compile-time error.
+Known Answer Tests require deterministic rng seeds, enable `kyber_kat` in `RUSTFLAGS`to use them. 
+Using this outside of `cargo test` will result in a compile-time error. 
+The test vector files are quite large, you will need to build them yourself from the C reference code. 
+There's a helper script to do this [here](./tests/KAT/build_kats.sh). 
 
 ```bash
-# This example runs all KATs for kyber512-90s.
-cargo test --features "KAT kyber512 90s"
-```
+# This example runs the basic tests for kyber768
+cargo test
 
-The test vector files are quite large, you will need to build them yourself from the C reference code. There's a helper script to do this [here](./tests/KAT/build_kats.sh). 
+# This runs the KATs for kyber512 in 90's mode
+RUSTFLAGS='--cfg kyber_kat' cargo test --features "kyber512 90s"
+```
 
 See the [testing readme](./tests/readme.md) for more comprehensive info.
 

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,9 @@
 
 
 # Kyber
-[![Build Status](https://github.com/Argyle-Software/kyber/actions/workflows/ci.yml/badge.svg)](https://github.com/Argyle-Software/kyber/actions)
+[![Build Status](https://github.com/Argyle-Software/kyber/actions/workflows/kat.yml/badge.svg)](https://github.com/Argyle-Software/kyber/actions)
 [![Crates](https://img.shields.io/crates/v/pqc-kyber)](https://crates.io/crates/pqc-kyber)
 [![NPM](https://img.shields.io/npm/v/pqc-kyber)](https://www.npmjs.com/package/pqc-kyber)
-[![dependency status](https://deps.rs/repo/github/Argyle-Software/kyber/status.svg)](https://deps.rs/repo/github/Argyle-Software/kyber)
 [![License](https://img.shields.io/crates/l/pqc_kyber)](https://github.com/Argyle-Software/kyber/blob/master/LICENSE-MIT)
 
 A rust implementation of the Kyber algorithm, a KEM standardised by the NIST Post-Quantum Standardization Project.
@@ -26,6 +25,8 @@ See the [**features**](#features) section for different options regarding securi
 It is recommended to use Kyber in a hybrid system alongside a traditional key exchange algorithm such as X25519. 
 
 Please also read the [**security considerations**](#security-considerations) before use.
+
+**Minimum Supported Rust Version: 1.47.0**
 
 ---
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -9,12 +9,12 @@ cd KAT
 
 Which will clone the C reference repo, generate the KAT files, then rename and put them in the correct folder for testing.
 
-To run the known answer tests you will need to use the `KAT` feature flag. To check different Kyber levels or 90's mode you will need to include those flags also. eg:
+To run the known answer tests you will need to enable `kyber_kat` in `RUSTFLAGS`. To check different Kyber levels or 90's mode you will need to include those flags also. eg:
 ```bash
-cargo test --features "KAT kyber1024 90s"
+RUSTFLAGS=' --cfg kyber-kat' cargo test --features "kyber1024 90s"
 ```
 
-For applicible x86 architectures you must export the avx2 RUSTFLAGS if you don't want to test on reference
+For applicible x86 architectures you must export the avx2 RUSTFLAGS if you don't want to test on the reference codebase.
 
 To run a matrix of all possible tests use the helper script from this folder:
 ```bash


### PR DESCRIPTION
Fix: readme CI badge
Removed: deps badge, it misleadingly shows outdated for dev-deps
Update: readmes for KAT RUSTFLAG usage 