### PR TITLE
Expose INDCPA-KYBER primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ kyber512 = []
 kyber768 = [] 
 kyber1024 = []
 
+### Export IND-CPA primitives
+# **WARNING** use with caution
+hazmat = []
+
 ### Additional features ###
 # 90s mode uses AES-CTR and SHA2 as primitives instead
 90s = ["sha2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,10 @@ mod reference;
 #[cfg(any(not(target_arch = "x86_64"), not(feature = "avx2")))] 
 use reference::*;
 
+#[cfg(any(not(target_arch = "x86_64"), not(feature = "avx2")))]
+#[cfg(feature = "hazmat")]
+pub use reference::indcpa;
+
 #[cfg(feature = "wasm")]
 mod wasm;
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -29,7 +29,7 @@ pub(crate) const KYBER_ETA1: usize = if cfg!(feature = "kyber512") { 3 } else { 
 pub(crate) const KYBER_ETA2: usize = 2;
 
 // Size of the hashes and seeds
-pub(crate) const KYBER_SYMBYTES: usize = 32;
+pub const KYBER_SYMBYTES: usize = 32;
 
 /// Size of the shared key 
 pub const KYBER_SSBYTES: usize =  32; 
@@ -47,9 +47,9 @@ pub(crate) const KYBER_POLYCOMPRESSEDBYTES: usize =     160;
 #[cfg(feature = "kyber1024")]
 pub(crate) const KYBER_POLYVECCOMPRESSEDBYTES: usize = KYBER_K * 352;
 
-pub(crate) const KYBER_INDCPA_PUBLICKEYBYTES: usize = KYBER_POLYVECBYTES + KYBER_SYMBYTES;
-pub(crate) const KYBER_INDCPA_SECRETKEYBYTES: usize = KYBER_POLYVECBYTES;
-pub(crate) const KYBER_INDCPA_BYTES: usize = KYBER_POLYVECCOMPRESSEDBYTES + KYBER_POLYCOMPRESSEDBYTES;
+pub const KYBER_INDCPA_PUBLICKEYBYTES: usize = KYBER_POLYVECBYTES + KYBER_SYMBYTES;
+pub const KYBER_INDCPA_SECRETKEYBYTES: usize = KYBER_POLYVECBYTES;
+pub const KYBER_INDCPA_BYTES: usize = KYBER_POLYVECCOMPRESSEDBYTES + KYBER_POLYCOMPRESSEDBYTES;
 
 /// Size in bytes of the Kyber public key
 pub const KYBER_PUBLICKEYBYTES: usize = KYBER_INDCPA_PUBLICKEYBYTES;

--- a/src/reference/indcpa.rs
+++ b/src/reference/indcpa.rs
@@ -240,7 +240,7 @@ pub fn indcpa_keypair<R>(
 //              public-key encryption scheme underlying Kyber.
 //
 // Arguments: - [u8] c:          output ciphertext (length KYBER_INDCPA_BYTES)
-//            - const [u8] m:    input message (length KYBER_INDCPA_MSGBYTES)
+//            - const [u8] m:    input message (length KYBER_SYMBYTES)
 //            - const [u8] pk:   input public key (length KYBER_INDCPA_PUBLICKEYBYTES)
 //            - const [u8] coin: input random coins used as seed (length KYBER_SYMBYTES)
 //                                  to deterministically generate all randomness
@@ -292,7 +292,7 @@ pub fn indcpa_enc(c: &mut[u8], m: &[u8], pk: &[u8], coins: &[u8])
 // Description: Decryption function of the CPA-secure
 //              public-key encryption scheme underlying Kyber.
 //
-// Arguments:   - [u8] m:        output decrypted message (of length KYBER_INDCPA_MSGBYTES)
+// Arguments:   - [u8] m:        output decrypted message (of length KYBER_SYMBYTES)
 //              - const [u8] c:  input ciphertext (of length KYBER_INDCPA_BYTES)
 //              - const [u8] sk: input secret key (of length KYBER_INDCPA_SECRETKEYBYTES)
 pub fn indcpa_dec(m: &mut[u8], c: &[u8], sk: &[u8])

--- a/src/reference/poly.rs
+++ b/src/reference/poly.rs
@@ -298,10 +298,10 @@ pub fn poly_sub(r: &mut Poly, a: &Poly)
 
 // Name:        poly_frommsg
 //
-// Description: Convert 32-byte message to polynomial
+// Description: Convert `KYBER_SYMBYTES`-byte message to polynomial
 //
 // Arguments:   - poly *r:                  output polynomial
-//              - const [u8] msg: input message
+//              - const [u8] msg: input message (of length KYBER_SYMBYTES)
 pub fn poly_frommsg(r: &mut Poly, msg: &[u8])
 {
   let mut mask;


### PR DESCRIPTION
This MR exposes the INDCPA-KYBER primitives:
- the functional modifications are done in the first commit;
- the second commit enforces the Unix encoding on the modified files.