### PR TITLE
Implement the standard library Error trait when "std" is enabled

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,3 +17,6 @@ impl core::fmt::Display for KyberError {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for KyberError {}


### PR DESCRIPTION
Without having this trait implemented, a lot of existing error handling code will refuse to work with this type.

My current use case is I have an error that encapsulates `KyberError` and I want to be able to return it from my own `std::error::Error::source` implementation. But I can't, because the signature for that method requires the source to of course also implement `std::error::Error`.