### PR TITLE
kem tests and fix readme

### DIFF
--- a/tests/kem.rs
+++ b/tests/kem.rs
@@ -18,5 +18,23 @@ fn keypair_encap_decap_invalid_ciphertext() {
   assert!(decapsulate(&ct, &keys.secret).is_err());
 }
 
+#[test]
+fn keypair_encap_pk_wrong_size() {
+  let mut rng = rand::thread_rng();
+  let pk: [u8; KYBER_PUBLICKEYBYTES + 3] = [1u8; KYBER_PUBLICKEYBYTES + 3];
+  assert!(encapsulate(&pk, &mut rng).is_err());
+}
 
+#[test]
+fn keypair_decap_ct_wrong_size() {
+  let ct: [u8; KYBER_CIPHERTEXTBYTES + 3] = [1u8; KYBER_CIPHERTEXTBYTES + 3];
+  let sk: [u8; KYBER_SECRETKEYBYTES] = [1u8; KYBER_SECRETKEYBYTES];
+  assert!(decapsulate(&ct, &sk).is_err());
+}
 
+#[test]
+fn keypair_decap_sk_wrong_size() {
+  let ct: [u8; KYBER_CIPHERTEXTBYTES] = [1u8; KYBER_CIPHERTEXTBYTES];
+  let sk: [u8; KYBER_SECRETKEYBYTES + 3] = [1u8; KYBER_SECRETKEYBYTES + 3];
+  assert!(decapsulate(&ct, &sk).is_err());
+}

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -11,7 +11,7 @@ Which will clone the C reference repo, generate the KAT files, then rename and p
 
 To run the known answer tests you will need to enable `kyber_kat` in `RUSTFLAGS`. To check different Kyber levels or 90's mode you will need to include those flags also. eg:
 ```bash
-RUSTFLAGS=' --cfg kyber-kat' cargo test --features "kyber1024 90s"
+RUSTFLAGS=' --cfg kyber_kat' cargo test --features "kyber1024 90s"
 ```
 
 For applicible x86 architectures you must export the avx2 RUSTFLAGS if you don't want to test on the reference codebase.


### PR DESCRIPTION
- added 3 kem tests to fill 2 sections that have not been covered by any test and concern input validation both encaps and decaps. Tested with grcov
- fix name of the kyber_kat cfg in readme file