### PR TITLE
use store64() for the same purpose (to store a 64bit integer as a byte array in little-endian order)

### DIFF
--- a/src/reference/fips202.rs
+++ b/src/reference/fips202.rs
@@ -499,10 +499,12 @@ pub(crate) fn keccak_squeeze(
       pos = 0
     }
     let mut i = pos;
+    let mut w = i/8;
     while i < r  && i < pos+outlen {
-      out[idx] = (s[i/8] >> 8*(i%8)) as u8;
-      i += 1;
-      idx += 1;
+      store64(&mut out[idx..], s[w]);
+      i += 8;
+      w += 1;
+      idx += 8;
     }
     outlen -= i-pos;
     pos = i;


### PR DESCRIPTION
I notice that the target line computes a simple store of a 64bit integer as a byte array in little-endian order. 
The `store64()` was created with this purpose and is already called in other functions.
Since both ways produce the same output with same elaboration time (on release mode) in order to have a more readable code this contribution was introduced.

@mberry 