### PR TITLE
Update keypair and client_init functions to use properly returned types

### DIFF
--- a/examples/ake.rs
+++ b/examples/ake.rs
@@ -5,11 +5,11 @@ fn main() -> Result<(), KyberError> {
 
   let mut alice = Ake::new();
   let mut bob = Ake::new();
-  let alice_keys = keypair(&mut rng)?;
-  let bob_keys = keypair(&mut rng)?;
+  let alice_keys = keypair(&mut rng);
+  let bob_keys = keypair(&mut rng);
 
   // Alice initiates key exchange with bob
-  let client_send = alice.client_init(&bob_keys.public, &mut rng)?;
+  let client_send = alice.client_init(&bob_keys.public, &mut rng);
   
   // Bob receives the request and authenticates Alice, sends 
   // encapsulated shared secret back

--- a/examples/kem.rs
+++ b/examples/kem.rs
@@ -4,7 +4,7 @@ fn main () -> Result<(), KyberError> {
   let mut rng = rand::thread_rng();
 
   // Alice generates a keypair
-  let alice_keys = keypair(&mut rng)?;
+  let alice_keys = keypair(&mut rng);
 
   // Bob encapsulates a shared secret
   let (ciphertext, shared_secret_bob) = encapsulate(&alice_keys.public, &mut rng)?;

--- a/examples/uake.rs
+++ b/examples/uake.rs
@@ -6,10 +6,10 @@ fn main() -> Result<(), KyberError> {
   let mut alice = Uake::new();
   let mut bob = Uake::new();
 
-  let bob_keys = keypair(&mut rng)?;
+  let bob_keys = keypair(&mut rng);
 
   // Alice initiates key exchange with bob
-  let client_send = alice.client_init(&bob_keys.public, &mut rng)?;
+  let client_send = alice.client_init(&bob_keys.public, &mut rng);
   
   // Bob receives the request and authenticates Alice, sends 
   // encapsulated shared secret back

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ export RUSTFLAGS="-C target-feature=+aes,+avx2,+sse2,+sse4.1,+bmi2,+popcnt"
 
 ```rust
 // Generate Keypair
-let keys_bob = keypair(&mut rng)?;
+let keys_bob = keypair(&mut rng);
 
 // Alice encapsulates a shared secret using Bob's public key
 let (ciphertext, shared_secret_alice) = encapsulate(&keys_bob.public, &mut rng)?;
@@ -77,10 +77,10 @@ let mut alice = Uake::new();
 let mut bob = Uake::new();
 
 // Generate Bob's Keypair
-let bob_keys = keypair(&mut rng)?;
+let bob_keys = keypair(&mut rng);
 
 // Alice initiates key exchange
-let client_init = alice.client_init(&bob_keys.public, &mut rng)?;
+let client_init = alice.client_init(&bob_keys.public, &mut rng);
 
 // Bob authenticates and responds
 let server_response = bob.server_receive(
@@ -103,10 +103,10 @@ Follows the same workflow except Bob requires Alice's public keys:
 let mut alice = Ake::new();
 let mut bob = Ake::new();
 
-let alice_keys = keypair(&mut rng)?;
-let bob_keys = keypair(&mut rng)?;
+let alice_keys = keypair(&mut rng);
+let bob_keys = keypair(&mut rng);
 
-let client_init = alice.client_init(&bob_keys.public, &mut rng)?;
+let client_init = alice.client_init(&bob_keys.public, &mut rng);
 
 let server_response = bob.server_receive(
   client_init, &alice_keys.public, &bob_keys.secret, &mut rng


### PR DESCRIPTION
Since these two functions do not return a result we can not use the "?" operator in the examples.