### PR TITLE
Add `no_std` build test on target with no std

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - name: no_std / no feat
+        run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      # cargo hack ensures all no_std features all built-checked
+      - name: no_std / cargo hack features
+        run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,getrandom,wasm,benchmarking,nasm,avx2,nasm-rs,cc
+


### PR DESCRIPTION
We use the same in [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek/blob/main/.github/workflows/workspace.yml#L60C1-L81C148)

I have a solution for the non-exclusive features.. will send a PR after this