### PR TITLE
Add import key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,8 @@ The KyberError enum has two variants:
 
 * **RandomBytesGeneration** - Error trying to fill random bytes (i.e external (hardware) RNG modules can fail).
 
+* **InvalidKey** - Given public and secret key does not match. Probably an input error.
+
 ---
 
 ## Features

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub enum KyberError {
     Decapsulation,
     /// Error trying to fill random bytes (i.e external (hardware) RNG modules can fail).
     RandomBytesGeneration,
+    /// Error when generating keys
+    InvalidKey,
 }
 
 impl core::fmt::Display for KyberError {
@@ -21,6 +23,9 @@ impl core::fmt::Display for KyberError {
             ),
             KyberError::RandomBytesGeneration => {
                 write!(f, "Random bytes generation function failed")
+            }
+            KyberError::InvalidKey => {
+                write!(f, "The secret and public key given does not match.")
             }
         }
     }

--- a/tests/kem.rs
+++ b/tests/kem.rs
@@ -10,7 +10,12 @@ fn keypair_encap_decap() {
     let ss2 = decapsulate(&ct, &keys.secret).unwrap();
     assert_eq!(ss1, ss2);
 }
-
+#[test]
+fn keypair_import_fake() {
+    let mut rng = rand::thread_rng();
+    let mut keys = keypair(&mut rng).unwrap();
+    let key = keypairfrom(&mut keys.public, &mut keys.secret, &mut rng).unwrap();
+}
 #[test]
 fn keypair_encap_decap_invalid_ciphertext() {
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Hello,

I was wondering if we could add a function to import keys (from IO or somewhere else) and check them. A test is already performed for that but no functions on the documentation allows to import keys and check them, only generating them from randomness. 

Therefore the programmer should code to detect if keys are valid (secret key matches the public key) if they are not generated by the script.

It also allows import zeroize on keypair and forbids copy.