### PR TITLE
Expose back IND-CPA Kyber primitives publicly

### DIFF
--- a/src/reference/indcpa.rs
+++ b/src/reference/indcpa.rs
@@ -1,6 +1,11 @@
 use crate::rng::randombytes;
 use crate::{params::*, poly::*, polyvec::*, symmetric::*, CryptoRng, KyberError, RngCore};
 
+#[cfg(feature = "hazmat")]
+pub use crate::params::{
+    KYBER_INDCPA_BYTES, KYBER_INDCPA_PUBLICKEYBYTES, KYBER_INDCPA_SECRETKEYBYTES,
+};
+
 /// Name:  pack_pk
 ///
 /// Description: Serialize the public key as concatenation of the


### PR DESCRIPTION
#36 exposed IND-CPA Kyber primitives, but #96 reduced the scope of publicly available parameters (see [here](https://github.com/Argyle-Software/kyber/pull/96/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R157-R160)).

This PR proposes to expose again `IND-CPA` parameters publicly, gated under `hazmat` feature.