### PR TITLE
changes function returns type

### DIFF
--- a/examples/ake.rs
+++ b/examples/ake.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), KyberError> {
         bob.server_receive(client_send, &alice_keys.public, &bob_keys.secret, &mut rng)?;
 
     // Alice autheticates and decapsulates
-    alice.client_confirm(server_send, &alice_keys.secret)?;
+    alice.client_confirm(server_send, &alice_keys.secret);
 
     // Both structs now have the shared secret
     assert_eq!(alice.shared_secret, bob.shared_secret);

--- a/examples/uake.rs
+++ b/examples/uake.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), KyberError> {
     let server_send = bob.server_receive(client_send, &bob_keys.secret, &mut rng)?;
 
     // Alice autheticates and decapsulates
-    alice.client_confirm(server_send)?;
+    alice.client_confirm(server_send);
 
     // Both structs now have the shared secret
     assert_eq!(alice.shared_secret, bob.shared_secret);

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ let server_response = bob.server_receive(
 )?;
 
 // Alice decapsulates the shared secret
-alice.client_confirm(server_response)?;
+alice.client_confirm(server_response);
 
 // Both key exchange structs now have the same shared secret
 assert_eq!(alice.shared_secret, bob.shared_secret);
@@ -112,7 +112,7 @@ let server_response = bob.server_receive(
   client_init, &alice_keys.public, &bob_keys.secret, &mut rng
 )?;
 
-alice.client_confirm(server_response, &alice_keys.secret)?;
+alice.client_confirm(server_response, &alice_keys.secret);
 
 assert_eq!(alice.shared_secret, bob.shared_secret);
 ```

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -48,10 +48,12 @@ type Eska = [u8; KYBER_SECRETKEYBYTES];
 ///
 /// let client_init = alice.client_init(&bob_keys.public, &mut rng)?;
 /// let server_send = bob.server_receive(client_init, &bob_keys.secret, &mut rng)?;
-/// let client_confirm = alice.client_confirm(server_send)?;
+/// let client_confirm = alice.client_confirm(server_send);
 ///
 /// assert_eq!(alice.shared_secret, bob.shared_secret);
-/// # Ok(()) }
+///  Ok(())
+/// 
+/// }
 
 #[cfg_attr(feature = "zeroize", derive(Zeroize, ZeroizeOnDrop))]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -158,12 +160,11 @@ impl Uake {
     /// # let bob_keys = keypair(&mut rng)?;
     /// let client_init = alice.client_init(&bob_keys.public, &mut rng)?;
     /// let server_send = bob.server_receive(client_init, &bob_keys.secret, &mut rng)?;
-    /// let client_confirm = alice.client_confirm(server_send)?;
+    /// let client_confirm = alice.client_confirm(server_send);
     /// assert_eq!(alice.shared_secret, bob.shared_secret);
     /// # Ok(()) }
-    pub fn client_confirm(&mut self, send_b: UakeSendResponse) -> Result<(), KyberError> {
-        uake_shared_a(&mut self.shared_secret, &send_b, &self.temp_key, &self.eska)?;
-        Ok(())
+    pub fn client_confirm(&mut self, send_b: UakeSendResponse) {
+        uake_shared_a(&mut self.shared_secret, &send_b, &self.temp_key, &self.eska)
     }
 }
 
@@ -183,7 +184,7 @@ impl Uake {
 ///
 /// let client_init = alice.client_init(&bob_keys.public, &mut rng)?;
 /// let server_send = bob.server_receive(client_init, &alice_keys.public, &bob_keys.secret, &mut rng)?;
-/// let client_confirm = alice.client_confirm(server_send, &alice_keys.secret)?;
+/// let client_confirm = alice.client_confirm(server_send, &alice_keys.secret);
 ///
 /// assert_eq!(alice.shared_secret, bob.shared_secret);
 /// # Ok(()) }
@@ -300,19 +301,14 @@ impl Ake {
     /// let client_confirm = alice.client_confirm(server_send, &alice_keys.secret);
     /// assert_eq!(alice.shared_secret, bob.shared_secret);
     /// # Ok(()) }
-    pub fn client_confirm(
-        &mut self,
-        send_b: AkeSendResponse,
-        secretkey: &SecretKey,
-    ) -> Result<(), KyberError> {
+    pub fn client_confirm(&mut self, send_b: AkeSendResponse, secretkey: &SecretKey) {
         ake_shared_a(
             &mut self.shared_secret,
             &send_b,
             &self.temp_key,
             &self.eska,
             secretkey,
-        )?;
-        Ok(())
+        )
     }
 }
 
@@ -355,12 +351,12 @@ where
 }
 
 // Unilaterally authenticated key exchange computation by Alice
-fn uake_shared_a(k: &mut [u8], recv: &[u8], tk: &[u8], sk: &[u8]) -> Result<(), KyberError> {
+#[inline]
+fn uake_shared_a(k: &mut [u8], recv: &[u8], tk: &[u8], sk: &[u8]) {
     let mut buf = [0u8; 2 * KYBER_SYMBYTES];
     crypto_kem_dec(&mut buf, recv, sk);
-    buf[KYBER_SYMBYTES..].copy_from_slice(&tk[..]);
+    buf[KYBER_SYMBYTES..].copy_from_slice(tk);
     kdf(k, &buf, 2 * KYBER_SYMBYTES);
-    Ok(())
 }
 
 // Authenticated key exchange initiation by Alice
@@ -410,13 +406,8 @@ where
 }
 
 // Mutually authenticated key exchange computation by Alice
-fn ake_shared_a(
-    k: &mut [u8],
-    recv: &[u8],
-    tk: &[u8],
-    sk: &[u8],
-    ska: &[u8],
-) -> Result<(), KyberError> {
+#[inline]
+fn ake_shared_a(k: &mut [u8], recv: &[u8], tk: &[u8], sk: &[u8], ska: &[u8]) {
     let mut buf = [0u8; 3 * KYBER_SYMBYTES];
     crypto_kem_dec(&mut buf, recv, sk);
     crypto_kem_dec(
@@ -424,7 +415,6 @@ fn ake_shared_a(
         &recv[KYBER_CIPHERTEXTBYTES..],
         ska,
     );
-    buf[2 * KYBER_SYMBYTES..].copy_from_slice(&tk[..]);
+    buf[2 * KYBER_SYMBYTES..].copy_from_slice(tk);
     kdf(k, &buf, 3 * KYBER_SYMBYTES);
-    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //! )?;
 //!
 //! // Alice decapsulates the shared secret
-//! alice.client_confirm(server_send)?;
+//! alice.client_confirm(server_send);
 //!
 //! // Both key exchange structs now have the shared secret
 //! assert_eq!(alice.shared_secret, bob.shared_secret);
@@ -104,7 +104,7 @@
 //!   client_init, &alice_keys.public, &bob_keys.secret, &mut rng
 //! )?;
 //!
-//! alice.client_confirm(server_send, &alice_keys.secret)?;
+//! alice.client_confirm(server_send, &alice_keys.secret);
 //!
 //! assert_eq!(alice.shared_secret, bob.shared_secret);
 //! # Ok(()) }
@@ -114,7 +114,7 @@
 //! ## Errors
 //! The [KyberError](enum.KyberError.html) enum handles errors. It has two variants:
 //!
-//! * **InvalidInput** - One or more byte inputs to a function are incorrectly sized. A likely cause of
+//! **InvalidInput** - One or more byte inputs to a function are incorrectly sized. A likely cause of
 //! this is two parties using different security levels while trying to negotiate a key exchange.
 //!
 //! * **Decapsulation** - The ciphertext was unable to be authenticated. The shared secret was not decapsulated  

--- a/tests/kex.rs
+++ b/tests/kex.rs
@@ -13,7 +13,7 @@ fn uake_valid() {
     let server_send = bob
         .server_receive(client_init, &bob_keys.secret, &mut rng)
         .unwrap();
-    alice.client_confirm(server_send).unwrap();
+    alice.client_confirm(server_send);
     assert_eq!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -26,9 +26,9 @@ fn uake_invalid_client_init_ciphertext() {
     let bob_keys = keypair(&mut rng).unwrap();
     let mut client_init = alice.client_init(&bob_keys.public, &mut rng).unwrap();
     client_init[KYBER_PUBLICKEYBYTES..][..4].copy_from_slice(&[255u8; 4]);
-    assert!(!bob
+    assert!(bob
         .server_receive(client_init, &bob_keys.secret, &mut rng)
-        .is_err());
+        .is_ok());
     assert_ne!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -44,7 +44,7 @@ fn uake_invalid_client_init_publickey() {
     let server_send = bob
         .server_receive(client_init, &bob_keys.secret, &mut rng)
         .unwrap();
-    assert!(!alice.client_confirm(server_send).is_err());
+    alice.client_confirm(server_send);
     assert_ne!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -60,7 +60,7 @@ fn uake_invalid_server_send_ciphertext() {
         .server_receive(client_init, &bob_keys.secret, &mut rng)
         .unwrap();
     server_send[..4].copy_from_slice(&[255u8; 4]);
-    assert!(!alice.client_confirm(server_send).is_err());
+    alice.client_confirm(server_send);
     assert_ne!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -77,9 +77,7 @@ fn ake_valid() {
     let server_send = bob
         .server_receive(client_init, &alice_keys.public, &bob_keys.secret, &mut rng)
         .unwrap();
-    let _client_confirm = alice
-        .client_confirm(server_send, &alice_keys.secret)
-        .unwrap();
+    let _client_confirm = alice.client_confirm(server_send, &alice_keys.secret);
     assert_eq!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -110,9 +108,7 @@ fn ake_invalid_client_init_publickey() {
     let server_send = bob
         .server_receive(client_init, &alice_keys.public, &bob_keys.secret, &mut rng)
         .unwrap();
-    assert!(!alice
-        .client_confirm(server_send, &alice_keys.secret)
-        .is_err());
+    alice.client_confirm(server_send, &alice_keys.secret);
     assert_ne!(alice.shared_secret, bob.shared_secret);
 }
 
@@ -128,9 +124,7 @@ fn ake_invalid_server_send_first_ciphertext() {
         .server_receive(client_init, &alice_keys.public, &bob_keys.secret, &mut rng)
         .unwrap();
     server_send[..4].copy_from_slice(&[255u8; 4]);
-    assert!(!alice
-        .client_confirm(server_send, &alice_keys.secret)
-        .is_err());
+    alice.client_confirm(server_send, &alice_keys.secret);
     assert_ne!(alice.shared_secret, bob.shared_secret);
 }
 


### PR DESCRIPTION
Change functions `uake_shared_a`, `uke_shared_a`, and `client_confirm` since they dont return errors.